### PR TITLE
fix home and asset detail page parameters update by side effects.

### DIFF
--- a/lib/ui/page/asset_detail.dart
+++ b/lib/ui/page/asset_detail.dart
@@ -34,7 +34,7 @@ class _AssetDetailLoader extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
-    final assetId = context.pathParameters['id']!;
+    final assetId = usePathParameter('id', path: assetDetailPath);
 
     useMemoizedFuture(() => context.appServices.updateAsset(assetId),
         keys: [assetId]);
@@ -58,19 +58,17 @@ class _AssetDetailLoader extends HookWidget {
       }
     }, [data?.assetId]);
 
+    final sortBy = useQueryParameter(_kQueryParamSortBy, path: assetDetailPath);
+    final filterBy =
+        useQueryParameter(_kQueryParamFilterBy, path: assetDetailPath);
+
     final filter = useMemoized(
-        () => SnapshotFilter(
-              sdk.EnumToString.fromString(SortBy.values,
-                      context.queryParameters[_kQueryParamSortBy]) ??
-                  SortBy.time,
-              sdk.EnumToString.fromString(FilterBy.values,
-                      context.queryParameters[_kQueryParamFilterBy]) ??
-                  FilterBy.all,
-            ),
-        [
-          context.queryParameters[_kQueryParamSortBy],
-          context.queryParameters[_kQueryParamFilterBy],
-        ]);
+      () => SnapshotFilter(
+        sdk.EnumToString.fromString(SortBy.values, sortBy) ?? SortBy.time,
+        sdk.EnumToString.fromString(FilterBy.values, filterBy) ?? FilterBy.all,
+      ),
+      [sortBy, filterBy],
+    );
 
     if (data == null) {
       return const SizedBox();

--- a/lib/ui/page/home.dart
+++ b/lib/ui/page/home.dart
@@ -43,12 +43,14 @@ class Home extends HookWidget {
 
     useMemoizedFuture(() => context.appServices.updateAssets());
 
+    final sortParam =
+        useQueryParameter(_kQueryParameterSort, path: homeUri.path);
+
     final sortType = useMemoized(
         () =>
-            sdk.EnumToString.fromString(_AssetSortType.values,
-                context.queryParameters[_kQueryParameterSort]) ??
+            sdk.EnumToString.fromString(_AssetSortType.values, sortParam) ??
             _AssetSortType.amount,
-        [context.queryParameters[_kQueryParameterSort]]);
+        [sortParam]);
 
     final assetResults = useMemoizedStream(
       () => context.appServices.assetResults().watch(),

--- a/lib/util/extension/src/provider.dart
+++ b/lib/util/extension/src/provider.dart
@@ -15,6 +15,8 @@ extension ProviderExtension on BuildContext {
 
   String get url => vRouter.url;
 
+  String get path => vRouter.path;
+
   void toExternal(Object url, {bool openNewTab = false}) =>
       vRouter.toExternal(url.toString(), openNewTab: openNewTab);
 

--- a/lib/util/hook.dart
+++ b/lib/util/hook.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 
+import 'extension/extension.dart';
+
 AsyncSnapshot<T> useMemoizedFuture<T>(
   Future<T> Function() futureBuilder, {
   T? initialData,
@@ -25,3 +27,35 @@ AsyncSnapshot<T> useMemoizedStream<T>(
       useMemoized<Stream<T>>(valueBuilder, keys),
       initialData: initialData,
     );
+
+String useQueryParameter(String key, {required String path}) {
+  final result = useRef('');
+
+  final context = useContext();
+  final parameter = context.queryParameters[key];
+  final currentPath = context.path;
+
+  useEffect(() {
+    if (parameter != result.value && path.pathMatch(currentPath)) {
+      result.value = parameter ?? '';
+    }
+  }, [parameter]);
+
+  return result.value;
+}
+
+String usePathParameter(String key, {required String path}) {
+  final result = useRef('');
+
+  final context = useContext();
+  final parameter = context.pathParameters[key];
+  final currentPath = context.path;
+
+  useEffect(() {
+    if (parameter != result.value && path.pathMatch(currentPath)) {
+      result.value = parameter ?? '';
+    }
+  }, [parameter]);
+
+  return result.value;
+}


### PR DESCRIPTION
fix some page (Home and AssetDetail) parameters update by side effects.

## For example

Currently user in `AssetDetail` page, and the path is:  **/tokens/aaaa** (`aaaa` is an asset id)

When user clicked a transaction. then the url will be route to SnapshotDetail: **/snapshot/bbbb** (`bbbb` is a snapshot id)

In `AssetDetail` page, we use `final assetId = context.pathParameters['id']!` to obtain the assetId and it is `aaaa`. However, after we routed to `SnapshotDetail` page ,the `assetId` which get from `pathParameters` will also updated to `bbbb`. and it cause by an side effect update which made `AssetDetail` page totally rebuilt.

## Solution

add `useQueryParameter` and `usePathParameter` functions to ensure the parameters only updated from the matched path.
