### PR TITLE
Revert "avoid TextField render wired in the latest flutter master. (#42)"

### DIFF
--- a/lib/ui/widget/transfer.dart
+++ b/lib/ui/widget/transfer.dart
@@ -392,8 +392,7 @@ class TransferAmountWidget extends HookWidget {
                         style: TextStyle(
                           color: context.colorScheme.primaryText,
                           fontSize: 16,
-                          // TODO change to w600 if https://github.com/flutter/flutter/issues/89568 fixed.
-                          fontWeight: FontWeight.w400,
+                          fontWeight: FontWeight.w600,
                         ),
                         maxLines: 1,
                         decoration: InputDecoration(
@@ -413,8 +412,7 @@ class TransferAmountWidget extends HookWidget {
                           suffixStyle: TextStyle(
                             color: context.colorScheme.primaryText,
                             fontSize: 16,
-                            // TODO change to w600 if https://github.com/flutter/flutter/issues/89568 fixed.
-                            fontWeight: FontWeight.w400,
+                            fontWeight: FontWeight.w600,
                           ),
                         ),
                         controller: controller,


### PR DESCRIPTION
revert #42 . this already fixed in https://github.com/flutter/flutter/issues/89568

This reverts commit 6318fe4d8c4a2bd9194e5c57d35b564f2663a650.