### PR TITLE
Remove iOS/android default page transition.

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -82,6 +82,8 @@ class _Router extends StatelessWidget {
               TargetPlatform.linux: FadeUpwardsPageTransitionsBuilder(),
               TargetPlatform.macOS: CupertinoPageTransitionsBuilder(),
               TargetPlatform.windows: FadeUpwardsPageTransitionsBuilder(),
+              TargetPlatform.iOS: _NoAnimationPageTransitionsBuilder(),
+              TargetPlatform.android: _NoAnimationPageTransitionsBuilder(),
             },
           ),
         ),
@@ -94,4 +96,17 @@ class _Router extends StatelessWidget {
         ),
         routes: buildMixinRoutes(context),
       );
+}
+
+class _NoAnimationPageTransitionsBuilder extends PageTransitionsBuilder {
+  const _NoAnimationPageTransitionsBuilder() : super();
+
+  @override
+  Widget buildTransitions<T>(
+          PageRoute<T> route,
+          BuildContext context,
+          Animation<double> animation,
+          Animation<double> secondaryAnimation,
+          Widget child) =>
+      child;
 }


### PR DESCRIPTION
since https://github.com/flutter/flutter/pull/89997 has been reverted.