### PR TITLE
Fix check support assets

### DIFF
--- a/lib/ui/page/swap.dart
+++ b/lib/ui/page/swap.dart
@@ -34,7 +34,7 @@ class Swap extends HookWidget {
     final swapClient = MixSwap.client;
     final supportedAssets = useMemoizedFuture(() async {
       var supportedIds = supportedAssetIds;
-      if (supportedIds == null) {
+      if (supportedIds == null || supportedIds.isEmpty) {
         supportedIds =
             (await swapClient.getAssets()).data.map((e) => e.uuid).toList();
       } else {


### PR DESCRIPTION
fix first time read `supportAssetIds` from cache not checking if it is empty