### PR TITLE
workaround for iOS 15.1 fallback fonts

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,8 @@ import 'ui/router/mixin_routes.dart';
 import 'ui/widget/brightness_observer.dart';
 import 'util/l10n.dart';
 import 'util/logger.dart';
+import 'util/web/web_utils_dummy.dart'
+    if (dart.library.html) 'util/web/web_utils.dart';
 
 Future<void> main() async {
   await initStorage();
@@ -85,6 +87,7 @@ class _Router extends StatelessWidget {
               TargetPlatform.android: _NoAnimationPageTransitionsBuilder(),
             },
           ),
+          fontFamily: getFallbackFontFamily(),
         ),
         builder: (BuildContext context, Widget child) => DefaultTextStyle(
           style: TextStyle(

--- a/lib/util/web/web_utils.dart
+++ b/lib/util/web/web_utils.dart
@@ -2,6 +2,8 @@
 
 import 'dart:html';
 
+import 'package:flutter/foundation.dart';
+
 void fixSafariIndexDb() {
   // fix safari indexedDb bug: https://bugs.webkit.org/show_bug.cgi?id=226547
   window.indexedDB!.open('dummy');
@@ -14,6 +16,26 @@ void setClipboardText(String text) {
   _select(fakeElement);
   _copyCommand();
   fakeElement.remove();
+}
+
+// https://github.com/flutter/engine/pull/29166
+// iOS 15.0 safari crash.
+String? getFallbackFontFamily() {
+  final userAgent = window.navigator.userAgent;
+  if (defaultTargetPlatform == TargetPlatform.iOS &&
+      userAgent.contains('OS 15_') &&
+      !userAgent.contains('OS 15_0')) {
+    // apply -apple-system font when version is not iOS 15.0, since
+    // iOS 15.1 fixed this crash.
+    return '-apple-system, BlinkMacSystemFont';
+  }
+  if (defaultTargetPlatform == TargetPlatform.macOS &&
+      userAgent.contains('OS X 10_15_6')) {
+    // use sans-serif as fallback font for OS X 10_15_6,
+    // since there is an crash for iPad 15.6 or macOS 11.6.
+    return 'sans-serif';
+  }
+  return null;
 }
 
 void _select(TextAreaElement element) {

--- a/lib/util/web/web_utils_dummy.dart
+++ b/lib/util/web/web_utils_dummy.dart
@@ -5,3 +5,5 @@ void fixSafariIndexDb() {}
 void setClipboardText(String text) {
   Clipboard.setData(ClipboardData(text: text));
 }
+
+String? getFallbackFontFamily() => null;


### PR DESCRIPTION
workaound for https://github.com/flutter/engine/pull/29166 cause iOS 15.1 english font becomes serif.