### PR TITLE
Fix search asset

### DIFF
--- a/lib/db/dao/asset_dao.dart
+++ b/lib/db/dao/asset_dao.dart
@@ -27,6 +27,25 @@ extension AssetConverter on sdk.Asset {
         depositEntries:
             Value(const DepositEntryConverter().mapToSql(depositEntries)),
       );
+
+  AssetsCompanion get asAssetsCompanionWithoutBalance => AssetsCompanion(
+        assetId: Value(assetId),
+        symbol: Value(symbol),
+        name: Value(name),
+        iconUrl: Value(iconUrl),
+        destination: Value(destination),
+        tag: Value(tag),
+        assetKey: Value(assetKey),
+        priceBtc: Value(priceBtc),
+        priceUsd: Value(priceUsd),
+        chainId: Value(chainId),
+        changeUsd: Value(changeUsd),
+        changeBtc: Value(changeBtc),
+        confirmations: Value(confirmations),
+        reserve: Value(reserve),
+        depositEntries:
+            Value(const DepositEntryConverter().mapToSql(depositEntries)),
+      );
 }
 
 @UseDao(tables: [Assets])
@@ -37,6 +56,16 @@ class AssetDao extends DatabaseAccessor<MixinDatabase> with _$AssetDaoMixin {
       into(db.assets).insertOnConflictUpdate(asset.asAssetsCompanion);
 
   Future<void> deleteAsset(Asset asset) => delete(db.assets).delete(asset);
+
+  Future<void> insertAllOnConflictUpdateWithoutBalance(
+      List<sdk.Asset> assets) async {
+    await db.batch((batch) {
+      batch.insertAllOnConflictUpdate(
+        db.assets,
+        assets.map((asset) => asset.asAssetsCompanionWithoutBalance).toList(),
+      );
+    });
+  }
 
   Future<void> insertAllOnConflictUpdate(List<sdk.Asset> assets) async {
     await db.batch((batch) {

--- a/lib/service/app_services.dart
+++ b/lib/service/app_services.dart
@@ -407,7 +407,8 @@ class AppServices extends ChangeNotifier with EquatableMixin {
   Future<void> searchAndUpdateAsset(String keyword) async {
     if (keyword.isEmpty) return;
     final mixinResponse = await client.assetApi.queryAsset(keyword);
-    await mixinDatabase.assetDao.insertAllOnConflictUpdate(mixinResponse.data);
+    await mixinDatabase.assetDao
+        .insertAllOnConflictUpdateWithoutBalance(mixinResponse.data);
   }
 
   Future<void> updateTopAssetIds() async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -413,13 +413,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
-  material_color_utilities:
-    dependency: transitive
-    description:
-      name: material_color_utilities
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.2"
   meta:
     dependency: transitive
     description:
@@ -762,7 +755,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
+    version: "0.4.7"
   timing:
     dependency: transitive
     description:


### PR DESCRIPTION
The asset balance from search must be 0, so we should ignore balance update.