### PR TITLE
fix nft removed if multisigs canceled

### DIFF
--- a/lib/util/transaction.dart
+++ b/lib/util/transaction.dart
@@ -137,9 +137,10 @@ Future<bool> showAndWaitingNftTransaction(
             return true;
           }
         } catch (error, stacktrace) {
+          // multisigs might be cancelled
           e('wait action: $error $stacktrace');
           showErrorToast(error.toDisplayString(context));
-          return true;
+          rethrow;
         }
         return false;
       },


### PR DESCRIPTION
if multisigs canceled, a 404 error would be raised, need rethrow it to interupt waiting process.